### PR TITLE
Add GNOME Terminal theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,3 +21,6 @@
 [submodule "kitty"]
 	path = kitty
 	url = https://github.com/challenger-deep-theme/kitty
+[submodule "gnome-terminal"]
+	path = gnome-terminal
+	url = https://github.com/woofers/challenger-deep-gnome-terminal


### PR DESCRIPTION
Adds a GNOME Terminal port of theme.

Most of the colors are exactly the same as those used in the iTerm theme.

The only color I am uncertain of is the selection color as there appears to be duplicate key in the iTerm theme

![profile](https://user-images.githubusercontent.com/7284672/57588605-7add0900-74cb-11e9-8360-4827fc8f4208.png)

![colors](https://user-images.githubusercontent.com/7284672/57588678-7d8c2e00-74cc-11e9-8b6b-8e75d841707b.png)

@MaxSt Please let me know if any colors are in-correct and I can update it.

Also I am happy to pull-request into another separate repo so that the GNOME Terminal theme is on the `challenger-deep-theme` GitHub org.
